### PR TITLE
Changes due to problems with concurrency

### DIFF
--- a/src/main/java/org/springframework/integration/x/rollover/file/RolloverFileMessageHandler.java
+++ b/src/main/java/org/springframework/integration/x/rollover/file/RolloverFileMessageHandler.java
@@ -50,7 +50,7 @@ public class RolloverFileMessageHandler extends AbstractMessageHandler implement
 
 	private AtomicLong messageCounter;
 	private volatile boolean running = false;
-	private OutputStream outputStream = null;
+	private RolloverFileOutputStream outputStream = null;
 
 	@Autowired
 	private FileCompressor fileCompressor;
@@ -113,11 +113,15 @@ public class RolloverFileMessageHandler extends AbstractMessageHandler implement
 
 		if (payload instanceof String) {
 			try {
+				outputStream.rollover();
+
 				String s = (String) payload;
 				if (!binary) {
 					s += "\n";
 				}
 				IOUtils.write(s, outputStream);
+
+				outputStream.rollover();
 			} catch (IOException e) {
 				logger.error("Failed to write payload to rollover output stream", e);
 			}

--- a/src/main/java/org/springframework/integration/x/rollover/file/RolloverFileMessageHandler.java
+++ b/src/main/java/org/springframework/integration/x/rollover/file/RolloverFileMessageHandler.java
@@ -113,14 +113,13 @@ public class RolloverFileMessageHandler extends AbstractMessageHandler implement
 
 		if (payload instanceof String) {
 			try {
-				outputStream.rollover();
-
 				String s = (String) payload;
 				if (!binary) {
 					s += "\n";
 				}
 				IOUtils.write(s, outputStream);
 
+				// rollover file after write completed.
 				outputStream.rollover();
 			} catch (IOException e) {
 				logger.error("Failed to write payload to rollover output stream", e);

--- a/src/main/java/org/springframework/integration/x/rollover/file/RolloverFileOutputStream.java
+++ b/src/main/java/org/springframework/integration/x/rollover/file/RolloverFileOutputStream.java
@@ -278,24 +278,7 @@ public class RolloverFileOutputStream extends FilterOutputStream {
 				// Start file roll over
 				synchronized (RolloverFileOutputStream.class) {
 					try {
-						setFile(true);
-						writtenBytesCounter.set(0);
-					} catch (IOException e) {
-						logger.error("roll over failed:", e);
-					}
-				}
-			}
-		}
-	}
-
-	private void checkFileSizeForRollover(long byteCount) {
-		if (maxRolledFileSize > 0) {
-			long fileSize = writtenBytesCounter.addAndGet(byteCount);
-			if (fileSize >= maxRolledFileSize) {
-				// Start file roll over
-				synchronized (RolloverFileOutputStream.class) {
-					try {
-						setFile(true);
+						setFile(false);
 						writtenBytesCounter.set(0);
 					} catch (IOException e) {
 						logger.error("roll over failed:", e);

--- a/src/main/resources/config/rollover-file.xml
+++ b/src/main/resources/config/rollover-file.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans 	xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xmlns:int="http://www.springframework.org/schema/integration"
+		xmlns:task="http://www.springframework.org/schema/task"
+	  	xmlns:int="http://www.springframework.org/schema/integration"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd
 		 	http://www.springframework.org/schema/context
     		http://www.springframework.org/schema/context/spring-context.xsd
+			http://www.springframework.org/schema/task
+			http://www.springframework.org/schema/task/spring-task.xsd
 			http://www.springframework.org/schema/integration
 			http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<task:executor id="taskExecutor" pool-size="1"/>
+	<task:scheduler id="taskScheduler" pool-size="1"/>
 
 	<context:component-scan base-package="org.springframework.integration.x.rollover.file.config" />
 


### PR DESCRIPTION
There have been some changes necessary:
- added single thread pool to ensure that module is being used single threaded (otherwise maybe problematic, when receiving data from topic)
- move file rollover to `MessageHandler` from `RolloverOutputStream` so that it is always ensured that a rollover doesn't happen within one Spring XD message
- disabled forceful renaming within `setFile` out of `rollover`

Without these changes
- files have been compressed more than once
- rolled over file contained garbage data

The issue can be verified when using the following stream configuration:

`stream create --name ro-producer --definition "time --timeUnit=NANOSECONDS --fixedDelay=100 > topic:time" --deploy`

`stream create --name ro-consumer --definition "topic:time > rollover-file1 --filename=/tmp/test_yyyy_mm_dd --dateFormat=yyyyMMdd_HHmmss --maxRolledFileSize=5000000 --rolloverPeriod=50000 --archivePrefix=archive --compressArchive=true --bufferSize=8192" --deploy`
